### PR TITLE
Revive with at least 20% ammunition in normal mode

### DIFF
--- a/autoload/PlayerData.gd
+++ b/autoload/PlayerData.gd
@@ -72,11 +72,15 @@ var player_exp = 0:
 		emit_signal("onPlayerExpChange",player_exp,max)
 
 #设置血量
-func resurrectPlayer(hp):
+func resurrectPlayer(hp, ammo_percentage):
 	if hp >= player_hp_max:
 		player_hp = player_hp_max
 	else:
 		player_hp = hp
+	if Utils.player.gun != null:
+		var player_ammo_percentage = (player_ammo / Utils.player.gun.bullets_max_count) * 100
+		if player_ammo_percentage < ammo_percentage:
+			player_ammo = Utils.player.gun.bullets_max_count * ammo_percentage * 0.01
 	emit_signal("onPlayerResurrect")
 
 #回复血量

--- a/game/map/mapTown/Town.gd
+++ b/game/map/mapTown/Town.gd
@@ -49,9 +49,9 @@ func onPlayerDeath():
 	ins.setOnClick(func callback(success):
 		if success:
 			LevelServer.isPause(false)
-			PlayerData.resurrectPlayer(PlayerData.player_hp_max)
+			PlayerData.resurrectPlayer(PlayerData.player_hp_max, 100)
 		else:
-			PlayerData.resurrectPlayer(1)
+			PlayerData.resurrectPlayer(1, 20)
 			onRoundEnd()
 		)
 	$CanvasLayer.add_child(ins)

--- a/game/reward/HpReward.gd
+++ b/game/reward/HpReward.gd
@@ -1,4 +1,4 @@
 extends BaseReward
 
 func onRewardStart():
-	PlayerData.resurrectPlayer(PlayerData.player_hp_max)
+	PlayerData.resurrectPlayer(PlayerData.player_hp_max, 100)


### PR DESCRIPTION
Add ammo_percentage parameter on `resurrectPlayer` function. So you don't die over and over if you run out of ammo.
This avoids dying over and over if you run out of ammunition.